### PR TITLE
Cache generated grammar regexps to improve performance

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,6 @@
 Revision history for Babble
 
+          - Performance improvement: cache generated grammar regexps.
 0.090008
           - No change from 0.090007_03.
 

--- a/lib/Babble/Grammar.pm
+++ b/lib/Babble/Grammar.pm
@@ -15,6 +15,8 @@ lazy rules => sub {
   +{ map +($_ => [ undef ]), keys %{ $_[0]->base_rule_names } }
 };
 
+# global cache of compiled grammar regexps
+my %COMPILE_CACHE;
 lazy grammar_regexp => sub {
   my ($self) = @_;
   my @parts;
@@ -35,7 +37,7 @@ lazy grammar_regexp => sub {
   # This stringify is required for Perl v5.18 - v5.28
   # (RT #126285, RT #144248).
   my $final_re = "${define_block} ${base_re}";
-  return qr{$final_re}x;
+  return $COMPILE_CACHE{$final_re} ||= qr{$final_re}x;
 };
 
 sub _rule_name {

--- a/lib/Babble/Match.pm
+++ b/lib/Babble/Match.pm
@@ -27,6 +27,7 @@ lazy top_re => sub {
   return "\\A${top}\\Z";
 };
 
+my %SUBMATCHES_COMPILE_CACHE;
 lazy submatches => sub {
   my ($self) = @_;
   return {} unless ref(my $top = $self->top_rule);
@@ -41,7 +42,8 @@ lazy submatches => sub {
       : $_
   } @$top;
   return {} unless @subrules;
-  my @values = $self->text =~ /\A${re}\Z ${\$self->grammar_regexp}/x;
+  my $submatch_re = qq[ \\A${re}\\Z ${\$self->grammar_regexp} ];
+  my @values = $self->text =~ ($SUBMATCHES_COMPILE_CACHE{$submatch_re} ||= qr/$submatch_re/x);
   die "Match failed" unless @values;
   my %submatches;
   require Babble::SubMatch;


### PR DESCRIPTION
This improves the performance of the test suite with a 30%-70% reduction
in execution time depending on how heavily the code generates grammar
regexps (with the greatest reduction for the `postfixderef` and
`substituteandreturn` tests) which can be seen in the following runs of
`prove --timer`:

Before:

```
t/plugin-coresignatures.t ....... ok     3640 ms ( 0.00 usr  0.00 sys +  3.53 cusr  0.10 csys =  3.63 CPU)
t/plugin-definedor.t ............ ok     1586 ms ( 0.00 usr  0.00 sys +  1.52 cusr  0.07 csys =  1.59 CPU)
t/plugin-ellipsis.t ............. ok      192 ms ( 0.00 usr  0.00 sys +  0.17 cusr  0.02 csys =  0.19 CPU)
t/plugin-packageblock.t ......... ok      281 ms ( 0.00 usr  0.00 sys +  0.24 cusr  0.04 csys =  0.28 CPU)
t/plugin-packageversion.t ....... ok      979 ms ( 0.01 usr  0.00 sys +  0.92 cusr  0.06 csys =  0.99 CPU)
t/plugin-postfixderef.t ......... ok    10813 ms ( 0.00 usr  0.00 sys + 10.59 cusr  0.23 csys = 10.82 CPU)
t/plugin-sigify.t ............... ok      394 ms ( 0.00 usr  0.00 sys +  0.37 cusr  0.02 csys =  0.39 CPU)
t/plugin-skt.t .................. ok      534 ms ( 0.00 usr  0.00 sys +  0.51 cusr  0.03 csys =  0.54 CPU)
t/plugin-state.t ................ ok     1713 ms ( 0.00 usr  0.00 sys +  1.63 cusr  0.08 csys =  1.71 CPU)
t/plugin-substituteandreturn.t .. ok    70323 ms ( 0.00 usr  0.00 sys + 70.09 cusr  0.24 csys = 70.33 CPU)
t/simple.t ...................... ok      356 ms ( 0.00 usr  0.00 sys +  0.33 cusr  0.02 csys =  0.35 CPU)
t/submatch-rule.t ............... ok      681 ms ( 0.00 usr  0.00 sys +  0.66 cusr  0.03 csys =  0.69 CPU)

All tests successful.
Files=12, Tests=79, 92 wallclock secs ( 0.03 usr  0.02 sys + 90.56 cusr  0.94 csys = 91.55 CPU)
Result: PASS
```

After:

```
t/plugin-coresignatures.t ....... ok     1825 ms ( 0.01 usr  0.00 sys +  1.78 cusr  0.04 csys =  1.83 CPU)
t/plugin-definedor.t ............ ok      890 ms ( 0.00 usr  0.00 sys +  0.83 cusr  0.06 csys =  0.89 CPU)
t/plugin-ellipsis.t ............. ok      150 ms ( 0.00 usr  0.00 sys +  0.13 cusr  0.02 csys =  0.15 CPU)
t/plugin-packageblock.t ......... ok      221 ms ( 0.00 usr  0.00 sys +  0.20 cusr  0.02 csys =  0.22 CPU)
t/plugin-packageversion.t ....... ok      401 ms ( 0.00 usr  0.00 sys +  0.36 cusr  0.04 csys =  0.40 CPU)
t/plugin-postfixderef.t ......... ok     5119 ms ( 0.00 usr  0.00 sys +  4.98 cusr  0.15 csys =  5.13 CPU)
t/plugin-sigify.t ............... ok      385 ms ( 0.00 usr  0.00 sys +  0.34 cusr  0.04 csys =  0.38 CPU)
t/plugin-skt.t .................. ok      428 ms ( 0.00 usr  0.00 sys +  0.38 cusr  0.05 csys =  0.43 CPU)
t/plugin-state.t ................ ok      795 ms ( 0.00 usr  0.00 sys +  0.75 cusr  0.05 csys =  0.80 CPU)
t/plugin-substituteandreturn.t .. ok    22202 ms ( 0.00 usr  0.00 sys + 22.15 cusr  0.05 csys = 22.20 CPU)
t/simple.t ...................... ok      329 ms ( 0.00 usr  0.00 sys +  0.29 cusr  0.04 csys =  0.33 CPU)
t/submatch-rule.t ............... ok      440 ms ( 0.00 usr  0.00 sys +  0.42 cusr  0.03 csys =  0.45 CPU)

All tests successful.
Files=12, Tests=79, 33 wallclock secs ( 0.04 usr  0.01 sys + 32.61 cusr  0.59 csys = 33.25 CPU)
Result: PASS
```
