### PR TITLE
SubstituteAndReturn: Faster search for contextual s///r, y///r

### DIFF
--- a/lib/Babble/Plugin/SubstituteAndReturn.pm
+++ b/lib/Babble/Plugin/SubstituteAndReturn.pm
@@ -88,46 +88,36 @@ sub _transform_binary {
 sub _transform_contextualise {
   my ($self, $top) = @_;
 
-  my $contextual_subst = 0;
   do {
     my %subst_pos;
     # Look for substitution without binding operator:
     # First look for an expression that begins with Substitution.
-    $top->each_match_within(Expression => [
-      [ subst => '(?>
-                      (?&PerlSubstitution)
-                    | (?&PerlTransliteration)
-                  )' ],
-    ] => sub {
+    $top->each_match_of( Expression => sub {
       my ($m) = @_;
-      my ($subst) = @{$m->submatches}{qw(subst)};
-      my ($flags) = $subst->text =~ _get_flags($subst->text);
+      my @s_pos = $m->match_positions_of('QuotelikeS');
+      my @t_pos = $m->match_positions_of('QuotelikeTR');
+      my @start_pos =
+          @s_pos && $s_pos[0][0] == 0
+        ? @{ $s_pos[0] }
+        : @t_pos && $t_pos[0][0] == 0
+        ? @{ $t_pos[0] }
+        : ();
+      return unless @start_pos;
+      my $text = substr($m->text, $start_pos[0], $start_pos[1]);
+      my ($flags) = $text =~ _get_flags($text);
       return unless $flags =~ /r/;
       $subst_pos{$m->start} = 1;
     });
-    # Then remove Substitution within a BinaryExpression
-    $top->each_match_within(BinaryExpression => [
-       [ 'left' => '(?>(?&PerlPrefixPostfixTerm))' ],
-       '(?>(?&PerlOWS)) =~ (?>(?&PerlOWS))',
-       [ 'right' => '(?>
-                         (?&PerlSubstitution)
-                       | (?&PerlTransliteration)
-                     )' ],
-    ] => sub {
-      my ($m) = @_;
-      delete $subst_pos{ $m->start + $m->submatches->{right}->start };
-    });
 
     # Insert context variable and binding operator
-    my @subst_pos = sort keys %subst_pos;
-    $contextual_subst = @subst_pos;
+    my @subst_pos = sort { $a <=> $b } keys %subst_pos;
     my $diff = 0;
     my $replace = '$_ =~ ';
     while( my $pos = shift @subst_pos ) {
       $top->replace_substring($pos + $diff, 0, $replace);
       $diff += length $replace;
     }
-  } while( $contextual_subst);
+  };
 }
 
 sub transform_to_plain {

--- a/lib/Babble/Plugin/SubstituteAndReturn.pm
+++ b/lib/Babble/Plugin/SubstituteAndReturn.pm
@@ -94,16 +94,21 @@ sub _transform_contextualise {
     # First look for an expression that begins with Substitution.
     $top->each_match_of( Expression => sub {
       my ($m) = @_;
-      my @s_pos = $m->match_positions_of('QuotelikeS');
-      my @t_pos = $m->match_positions_of('QuotelikeTR');
-      my @start_pos =
-          @s_pos && $s_pos[0][0] == 0
-        ? @{ $s_pos[0] }
-        : @t_pos && $t_pos[0][0] == 0
-        ? @{ $t_pos[0] }
-        : ();
-      return unless @start_pos;
-      my $text = substr($m->text, $start_pos[0], $start_pos[1]);
+      my $expr_text = $m->text;
+      my @start_pos = do {
+        if( $expr_text =~ /\A s/x ) {
+          my @s_pos = $m->match_positions_of('QuotelikeS');
+          return unless @s_pos && $s_pos[0][0] == 0;
+          @{ $s_pos[0] };
+        } elsif( $expr_text =~ /\A (?:y|tr)/x ) {
+          my @t_pos = $m->match_positions_of('QuotelikeTR');
+          return unless @t_pos && $t_pos[0][0] == 0;
+          @{ $t_pos[0] };
+        } else {
+          return;
+        }
+      };
+      my $text = substr($expr_text, $start_pos[0], $start_pos[1]);
       my ($flags) = $text =~ _get_flags($text);
       return unless $flags =~ /r/;
       $subst_pos{$m->start} = 1;

--- a/lib/Babble/Plugin/SubstituteAndReturn.pm
+++ b/lib/Babble/Plugin/SubstituteAndReturn.pm
@@ -89,7 +89,7 @@ sub _transform_contextualise {
   my ($self, $top) = @_;
 
   do {
-    my %subst_pos;
+    my @subst_pos; # sorted positions
     # Look for substitution without binding operator:
     # First look for an expression that begins with Substitution.
     $top->each_match_of( Expression => sub {
@@ -111,11 +111,10 @@ sub _transform_contextualise {
       my $text = substr($expr_text, $start_pos[0], $start_pos[1]);
       my ($flags) = $text =~ _get_flags($text);
       return unless $flags =~ /r/;
-      $subst_pos{$m->start} = 1;
+      push @subst_pos, $m->start;
     });
 
     # Insert context variable and binding operator
-    my @subst_pos = sort { $a <=> $b } keys %subst_pos;
     my $diff = 0;
     my $replace = '$_ =~ ';
     while( my $pos = shift @subst_pos ) {


### PR DESCRIPTION
- Faster search for contextual `s///r`, `y///r`
- SubstituteAndReturn: Check beginning of expression text to find positions
- SubstituteAndReturn: use array instead of hash for positions

---

## Performance

### Before

```
t/plugin-substituteandreturn.t .. ok    17590 ms ( 0.00 usr  0.00 sys + 17.53 cusr  0.05 csys = 17.58 CPU)

All tests successful.
Files=1, Tests=8, 18 wallclock secs ( 0.01 usr  0.00 sys + 17.53 cusr  0.05 csys = 17.59 CPU)
Result: PASS
```


### After

```
t/plugin-substituteandreturn.t .. ok     2016 ms ( 0.00 usr  0.00 sys +  1.98 cusr  0.03 csys =  2.01 CPU)

All tests successful.
Files=1, Tests=8,  2 wallclock secs ( 0.01 usr  0.00 sys +  1.98 cusr  0.03 csys =  2.02 CPU)
Result: PASS
```
